### PR TITLE
BUGFIX: Removed index_name in FieldMapping

### DIFF
--- a/Classes/Mapping/EntityMappingBuilder.php
+++ b/Classes/Mapping/EntityMappingBuilder.php
@@ -131,7 +131,9 @@ class EntityMappingBuilder
                     if (isset($multiFields[$multiFieldIndexName])) {
                         throw new ElasticSearchException('Duplicate index name in the same multi field is not allowed "' . $className . '::' . $propertyName . '".');
                     }
-                    $multiFieldAnnotation->type = $mappingType;
+                    if (!$multiFieldAnnotation->type) {
+                        $multiFieldAnnotation->type = $mappingType;
+                    }
                     $multiFields[$multiFieldIndexName] = $this->processMappingAnnotation($multiFieldAnnotation);
                 }
                 $mapping->setPropertyByPath([$propertyName, 'fields'], $multiFields);
@@ -150,7 +152,9 @@ class EntityMappingBuilder
             if ($directiveValue === null) {
                 continue;
             }
-            $propertyMapping = Arrays::setValueByPath($propertyMapping, $mappingDirective, $directiveValue);
+            if ($mappingDirective != 'index_name') {
+                $propertyMapping = Arrays::setValueByPath($propertyMapping, $mappingDirective, $directiveValue);
+            }
         }
 
         return $propertyMapping;


### PR DESCRIPTION
Using MultiField `index_name` would get added to the field-definition.
See: https://www.elastic.co/guide/en/elasticsearch/reference/7.10/indices-put-mapping.html#add-multi-fields-existing-field-ex